### PR TITLE
Seed hardware-address with SecureRandom

### DIFF
--- a/src/flake/core.clj
+++ b/src/flake/core.clj
@@ -54,9 +54,14 @@
 ;; TODO: Should throw an error if no network interface found.
 (defonce ^{:private true}
   hardware-address
-  (-> (InetAddress/getLocalHost)
-      NetworkInterface/getByInetAddress
-      .getHardwareAddress))
+  (try
+    (-> (InetAddress/getLocalHost)
+        NetworkInterface/getByInetAddress
+        .getHardwareAddress)
+    (catch java.net.UnknownHostException _
+      (let [bytes (byte-array 6)]
+        (.nextBytes (java.security.SecureRandom.) bytes)
+        bytes))))
 
 ;; Persistent timer
 (defn write-timestamp

--- a/src/flake/core.clj
+++ b/src/flake/core.clj
@@ -59,6 +59,10 @@
         NetworkInterface/getByInetAddress
         .getHardwareAddress)
     (catch java.net.UnknownHostException _
+      (binding [*out* *err*]
+        (println "[flake.core]"
+                 "No local host address found."
+                 "Falling back to SecureRandom."))
       (let [bytes (byte-array 6)]
         (.nextBytes (java.security.SecureRandom.) bytes)
         bytes))))


### PR DESCRIPTION
If no local network interface is detected `InetAddress/getLocalHost` throws
a UnknownHostException when compiling the flake.core ns. This patch handles
such scenario by seeding hardware-address using SecureRandom.