### PR TITLE
catch IOException occuring when path does not exist.

### DIFF
--- a/src/flake/timer.clj
+++ b/src/flake/timer.clj
@@ -21,4 +21,5 @@
   [path]
   (try
     (read-string (slurp path))
-    (catch java.lang.RuntimeException _ 0)))
+    (catch java.lang.RuntimeException _ 0)
+    (catch java.io.IOException _ 0)))


### PR DESCRIPTION
currently just catches java.lang.RuntimeException but docstring implies it should catch IOException as the FileNotFoundException which occurs when file does not exist is not caught (since RuntimeException is not in the same inheritance chain).