### PR TITLE
Explicitly parse the timestamp and guard against empty file

### DIFF
--- a/src/flake/timer.clj
+++ b/src/flake/timer.clj
@@ -20,6 +20,7 @@
   "Reads a timestamp from path. If the path is not a file, returns 0."
   [path]
   (try
-    (read-string (slurp path))
+    (Integer/parseInt (slurp path))
+    (catch java.lang.NumberFormatException _ 0)
     (catch java.lang.RuntimeException _ 0)
     (catch java.io.IOException _ 0)))

--- a/src/flake/timer.clj
+++ b/src/flake/timer.clj
@@ -17,10 +17,9 @@
       (recur (+ 1e3 next-update)))))
 
 (defn read-timestamp
-  "Reads a timestamp from path. If the path is not a file, returns 0."
+  "Reads a timestamp from path. If the path is not a file or the file is empty, returns 0."
   [path]
   (try
     (Integer/parseInt (slurp path))
     (catch java.lang.NumberFormatException _ 0)
-    (catch java.lang.RuntimeException _ 0)
     (catch java.io.IOException _ 0)))

--- a/test/flake/test_timer.clj
+++ b/test/flake/test_timer.clj
@@ -30,3 +30,9 @@
 (deftest test-read-timestamp-not-a-path
   (let [test-ts-path (gensym "not-a-path")]
     (is (= (timer/read-timestamp test-ts-path) 0))))
+
+
+(deftest test-read-empty-file
+  (let [test-ts-path (java.io.File/createTempFile
+                      "flake-test-timestamp-empty" ".txt")]
+    (is (= (timer/read-timestamp test-ts-path) 0))))


### PR DESCRIPTION
Our services use [kithara](https://github.com/xsc/kithara) as a basis for our internal job processing framework. Kithara depends on flake and today we got affected by a quite weird issue

Because of reasons which are still not 100% clear - one of our services managed to create an empt y`/tmp/flake-timestamp-dets` file. That didn't crash the service, instead it appeared to be working, but our error tracker picked up an exception pointing at flake, not in kithara.

I've changed how the timestamp value is read from the file - rather than using (potentially) unsafe `read-string` I've switched to an explicit parsing and added a guard against an empty value.

---

My only doubt is - was there a reason behind using `read-string` rather than explicit cast?
`flake.core` uses `>` to later compare the value which of course would fail if the file happened to have something that wasn't a string.
