### PR TITLE
Improve performance of flake.utils/encode

### DIFF
--- a/src/flake/utils.clj
+++ b/src/flake/utils.clj
@@ -12,13 +12,14 @@
 (defn encode
   "Encodes n in a new base of ks."
   [ks n]
-  (let [base (count ks)]
-    (->> (iterate #(quot % base) n)
-         (take-while pos?)
-         (reduce (fn [acc n]
-                   (conj acc (nth ks (mod n base))))
-                 nil)
-         (apply str))))
+  (let [ks   (.toCharArray ^String ks)
+        base (alength ks)
+        sb   (StringBuffer.)]
+    (loop [n n]
+      (if (pos? n)
+        (do (.append sb (aget ks (mod n base)))
+            (recur (quot n base)))
+        (.toString (.reverse sb))))))
 
 (def ^{:doc "Encodes a given value into a base62 representation."}
   base62-encode


### PR DESCRIPTION
This patch doubles the performance of the Base62 encoding utility function. On my machine, it reduces the time to encode a flake from just over 12μs to just under 6μs, as measured by Criterium.